### PR TITLE
Fix kube-vip bgp_peers variable

### DIFF
--- a/roles/k3s_server/templates/vip.yaml.j2
+++ b/roles/k3s_server/templates/vip.yaml.j2
@@ -61,14 +61,14 @@ spec:
         - name: bgp_routerid
           value: "{{ kube_vip_bgp_routerid }}"
 {% endif %}
-{% if _kube_vip_bgp_peers | length > 0 %}
-        - name: bgppeers
-          value: "{{ _kube_vip_bgp_peers | map(attribute='peer_address') | zip(_kube_vip_bgp_peers| map(attribute='peer_asn')) | map('join', ',') | join(':') }}"  # yamllint disable-line rule:line-length
-{% else %}
 {% if kube_vip_bgp_as is defined %}
         - name: bgp_as
           value: "{{ kube_vip_bgp_as }}"
 {% endif %}
+{% if _kube_vip_bgp_peers | length > 0 %}
+        - name: bgp_peers
+          value: "{{ _kube_vip_bgp_peers | map(attribute='peer_address') | zip(_kube_vip_bgp_peers| map(attribute='peer_asn')) | map('join', ':') | join(',') }}"  # yamllint disable-line rule:line-length
+{% else %}
 {% if kube_vip_bgp_peeraddress is defined %}
         - name: bgp_peeraddress
           value: "{{ kube_vip_bgp_peeraddress }}"


### PR DESCRIPTION
Rearranged bgp_as and resolved spelling error bgp_peers

Import of https://github.com/techno-tim/k3s-ansible/pull/634