### PR TITLE
Fix YAML formatting in custom registries task

### DIFF
--- a/roles/k3s_custom_registries/tasks/main.yml
+++ b/roles/k3s_custom_registries/tasks/main.yml
@@ -11,6 +11,6 @@
 - name: Insert registries into /etc/rancher/k3s/registries.yaml
   ansible.builtin.blockinfile:
     path: /etc/rancher/k3s/registries.yaml
-    block: "{{ custom_registries_yaml }}"
+    block: "{{ custom_registries_yaml | to_yaml(indent=2) }}"
     mode: "0600"
     create: true


### PR DESCRIPTION
Apply proper YAML formatting to custom_registries_yaml variable using the to_yaml filter to ensure correct indentation and structure in the registries.yaml file.