### PR TITLE
Add configurable custom DNS resolver support for k3s

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,8 @@ See the commands [here](https://technotim.live/posts/k3s-etcd-ansible/#testing-y
 | `k3s_agent`, `k3s_server` | `proxy_env.HTTPS_PROXY` | string | ❌ | Required | HTTP internet proxy |
 | `k3s_agent`, `k3s_server` | `proxy_env.NO_PROXY` | string | ❌ | Required | Addresses that will not use the proxies |
 | `k3s_agent`, `k3s_server`, `reset` | `systemd_dir` | string | `/etc/systemd/system` | Not required | Path to systemd services |
+| `k3s_agent`, `k3s_server` | `k3s_resolvconf_nameserver` | list | `[]` | Not required | List of nameservers for custom resolv.conf |
+| `k3s_agent`, `k3s_server` | `k3s_resolvconf_search` | string | `""` | Not required | Search domain for custom resolv.conf |
 | `k3s_custom_registries` | `custom_registries_yaml` | string | ❌ | Required | YAML block defining custom registries. The following is an example that pulls all images used in this playbook through your private registries. It also allows you to pull your own images from your private registry, without having to use imagePullSecrets in your deployments. If all you need is your own images and you don't care about caching the docker/quay/ghcr.io images, you can just remove those from the mirrors: section. |
 | `k3s_server`, `k3s_server_post` | `cilium_bgp` | bool | `~` | Not required | Enable cilium BGP control plane for LB services and pod cidrs. Disables the use of MetalLB. |
 | `k3s_server`, `k3s_server_post` | `cilium_iface` | string | ❌ | Not required | The network interface used for when Cilium is enabled |

--- a/roles/k3s_agent/defaults/main.yml
+++ b/roles/k3s_agent/defaults/main.yml
@@ -2,3 +2,6 @@
 extra_agent_args: ""
 group_name_master: master
 systemd_dir: /etc/systemd/system
+
+k3s_resolvconf_nameserver: []
+k3s_resolvconf_search: ""

--- a/roles/k3s_agent/tasks/main.yml
+++ b/roles/k3s_agent/tasks/main.yml
@@ -20,6 +20,25 @@
   ansible.builtin.include_tasks: http_proxy.yml
   when: proxy_env is defined
 
+- name: Create /etc/rancher/k3s directory
+  ansible.builtin.file:
+    path: /etc/rancher/k3s
+    state: directory
+    owner: root
+    group: root
+    mode: "0755"
+  when: k3s_resolvconf_nameserver | length > 0
+
+- name: Create custom resolv.conf for k3s
+  ansible.builtin.template:
+    src: resolv.conf.j2
+    dest: /etc/rancher/k3s/resolv.conf
+    owner: root
+    group: root
+    mode: "0644"
+  when: k3s_resolvconf_nameserver | length > 0
+  notify: restart k3s-node
+
 - name: Configure the k3s service
   ansible.builtin.template:
     src: k3s.service.j2

--- a/roles/k3s_agent/templates/k3s.service.j2
+++ b/roles/k3s_agent/templates/k3s.service.j2
@@ -11,6 +11,7 @@ ExecStartPre=-/sbin/modprobe overlay
 ExecStart=/usr/local/bin/k3s agent \
   --server https://{{ apiserver_endpoint | ansible.utils.ipwrap }}:6443 \
   {% if is_pxe_booted | default(false) %}--snapshotter native \
+  {% endif %}{% if k3s_resolvconf_nameserver | length > 0 %}--resolv-conf /etc/rancher/k3s/resolv.conf \
   {% endif %}--token {{ hostvars[groups[group_name_master | default('master')][0]]['token'] | default(k3s_token) }} \
   {{ extra_agent_args }}
 KillMode=process

--- a/roles/k3s_agent/templates/resolv.conf.j2
+++ b/roles/k3s_agent/templates/resolv.conf.j2
@@ -1,0 +1,8 @@
+{% if k3s_resolvconf_nameserver | length > 0 %}
+{% for nameserver in k3s_resolvconf_nameserver %}
+nameserver {{ nameserver }}
+{% endfor %}
+{% if k3s_resolvconf_search | length > 0 %}
+search {{ k3s_resolvconf_search }}
+{% endif %}
+{% endif %}

--- a/roles/k3s_server/defaults/main.yml
+++ b/roles/k3s_server/defaults/main.yml
@@ -38,3 +38,6 @@ server_init_args: >-
   {{ extra_server_args }}
 
 systemd_dir: /etc/systemd/system
+
+k3s_resolvconf_nameserver: []
+k3s_resolvconf_search: ""

--- a/roles/k3s_server/tasks/main.yml
+++ b/roles/k3s_server/tasks/main.yml
@@ -22,6 +22,25 @@
   ansible.builtin.include_tasks: http_proxy.yml
   when: proxy_env is defined
 
+- name: Create /etc/rancher/k3s directory
+  ansible.builtin.file:
+    path: /etc/rancher/k3s
+    state: directory
+    owner: root
+    group: root
+    mode: "0755"
+  when: k3s_resolvconf_nameserver | length > 0
+
+- name: Create custom resolv.conf for k3s
+  ansible.builtin.template:
+    src: resolv.conf.j2
+    dest: /etc/rancher/k3s/resolv.conf
+    owner: root
+    group: root
+    mode: "0644"
+  when: k3s_resolvconf_nameserver | length > 0
+  notify: restart k3s
+
 - name: Deploy vip manifest
   ansible.builtin.include_tasks: vip.yml
 - name: Deploy metallb manifest

--- a/roles/k3s_server/templates/k3s.service.j2
+++ b/roles/k3s_server/templates/k3s.service.j2
@@ -7,7 +7,7 @@ After=network-online.target
 Type=notify
 ExecStartPre=-/sbin/modprobe br_netfilter
 ExecStartPre=-/sbin/modprobe overlay
-ExecStart=/usr/local/bin/k3s server {{ extra_server_args | default("") }}
+ExecStart=/usr/local/bin/k3s server{% if k3s_resolvconf_nameserver | length > 0 %} --resolv-conf /etc/rancher/k3s/resolv.conf{% endif %} {{ extra_server_args | default("") }}
 KillMode=process
 Delegate=yes
 # Having non-zero Limit*s causes performance problems due to accounting overhead

--- a/roles/k3s_server/templates/resolv.conf.j2
+++ b/roles/k3s_server/templates/resolv.conf.j2
@@ -1,0 +1,8 @@
+{% if k3s_resolvconf_nameserver | length > 0 %}
+{% for nameserver in k3s_resolvconf_nameserver %}
+nameserver {{ nameserver }}
+{% endfor %}
+{% if k3s_resolvconf_search | length > 0 %}
+search {{ k3s_resolvconf_search }}
+{% endif %}
+{% endif %}


### PR DESCRIPTION
- Add k3s_resolvconf_nameserver (list) and k3s_resolvconf_search (string) parameters
- Create custom resolv.conf template for both k3s_server and k3s_agent roles
- Configure k3s service with --resolv-conf parameter when nameservers are set
- Add tasks to create /etc/rancher/k3s directory and resolv.conf file
- Update documentation with new parameters in README

This helps to get rid of "Nameserver limits were exceeded, some nameservers have been omitted" warnings.

AI-assisted: Claude Code