### PR TITLE
Add configurable k3s_cilium_cli variable for Cilium CLI installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,7 @@ See the commands [here](https://technotim.live/posts/k3s-etcd-ansible/#testing-y
 | `k3s_server_post` | `cilium_exportPodCIDR` | bool | `true` | Not required | Export pod CIDR |
 | `k3s_server_post` | `cilium_hubble` | bool | `true` | Not required | Enable Cilium Hubble |
 | `k3s_server_post` | `cilium_hubble_ui_lb` | bool | `false` | Not required | Enable LoadBalancer service type for Hubble UI |
+| `k3s_server_post` | `cilium_cli` | bool | `true` | Not required | Install and configure Cilium CLI on first master node |
 | `k3s_server_post` | `cilium_mode` | string | `native` | Not required | Inner-node communication mode (choices are `native` and `routed`) |
 | `k3s_server_post` | `cluster_cidr` | string | `10.52.0.0/16` | Not required | Inner-cluster IP range |
 | `k3s_server_post` | `enable_bpf_masquerade` | bool | `true` | Not required | Use IP masquerading |

--- a/roles/k3s_server_post/tasks/cilium.yml
+++ b/roles/k3s_server_post/tasks/cilium.yml
@@ -1,6 +1,8 @@
 ---
 - name: Prepare Cilium CLI on first master and deploy CNI
-  when: ansible_hostname == hostvars[groups[group_name_master | default('master')][0]]['ansible_hostname']
+  when:
+    - ansible_hostname == hostvars[groups[group_name_master | default('master')][0]]['ansible_hostname']
+    - cilium_cli | default(true) | bool
   run_once: true
   block:
     - name: Create tmp directory on first master


### PR DESCRIPTION
Add k3s_cilium_cli variable to control Cilium CLI installation on first master. The default value is true.